### PR TITLE
Add Camera Focus Drill

### DIFF
--- a/src/main/kotlin/org/abimon/osl/OpenSpiralLanguageParser.kt
+++ b/src/main/kotlin/org/abimon/osl/OpenSpiralLanguageParser.kt
@@ -391,6 +391,7 @@ open class OpenSpiralLanguageParser(private val oslContext: (String) -> ByteArra
                             LinBustSpriteDrill,
                             LinHideSpriteDrill,
                             LinUIDrill,
+                            LinCameraFocusDrill,
                             LinIfDrill,
                             LinIfGameStateDrill,
                             LinIfRandDrill,

--- a/src/main/kotlin/org/abimon/osl/drills/lin/LinCameraFocusDrill.kt
+++ b/src/main/kotlin/org/abimon/osl/drills/lin/LinCameraFocusDrill.kt
@@ -14,7 +14,7 @@ import kotlin.reflect.KClass
 
 object LinCameraFocusDrill : DrillHead<LinScript> {
     val cmd: String = "LIN-CAMERA-FOCUS"
-    val NAME = AllButMatcher(charArrayOf(':', '\n'))
+
     val NUMERAL_REGEX = "\\d+".toRegex()
 
     override val klass: KClass<LinScript> = LinScript::class
@@ -24,28 +24,18 @@ object LinCameraFocusDrill : DrillHead<LinScript> {
                     clearTmpStack(cmd),
 
                     Sequence(
-                            "Focus camera on",
+                            FirstOf("Focus camera on", "Set camera focus to", "Camera Focus:"),
                             pushDrillHead(cmd, this@LinCameraFocusDrill),
                             InlineWhitespace(),
-                            FirstOf(
-                                    Parameter(cmd),
-                                    Sequence(
-                                            OneOrMore(Digit()),
-                                            pushTmpAction(cmd)
-                                    )
-                            ),
-                            pushTmpAction(cmd)
+                            OneOrMore(Digit()),
+                            pushTmpFromStack(cmd)
                     ),
 
                     pushStackWithHead(cmd)
             )
 
     override fun operate(parser: OpenSpiralLanguageParser, rawParams: Array<Any>): LinScript {
-        val uiStateStr = rawParams[0].toString()
-
-        val uiState: Int
-
-        uiState = uiStateStr.toIntOrNull() ?: 0
+        val uiState = rawParams[0].toString().toIntOrNull() ?: 0
 
         return when(parser.hopesPeakGame) {
             DR1 -> ChangeUIEntry(26, uiState)

--- a/src/main/kotlin/org/abimon/osl/drills/lin/LinCameraFocusDrill.kt
+++ b/src/main/kotlin/org/abimon/osl/drills/lin/LinCameraFocusDrill.kt
@@ -1,0 +1,55 @@
+package org.abimon.osl.drills.lin
+
+import org.abimon.osl.AllButMatcher
+import org.abimon.osl.OpenSpiralLanguageParser
+import org.abimon.osl.drills.DrillHead
+import org.abimon.spiral.core.objects.game.hpa.DR1
+import org.abimon.spiral.core.objects.game.hpa.DR2
+import org.abimon.spiral.core.objects.game.hpa.UnknownHopesPeakGame
+import org.abimon.spiral.core.objects.scripting.lin.LinScript
+import org.abimon.spiral.core.objects.scripting.lin.ChangeUIEntry
+import org.parboiled.Action
+import org.parboiled.Rule
+import kotlin.reflect.KClass
+
+object LinCameraFocusDrill : DrillHead<LinScript> {
+    val cmd: String = "LIN-CAMERA-FOCUS"
+    val NAME = AllButMatcher(charArrayOf(':', '\n'))
+    val NUMERAL_REGEX = "\\d+".toRegex()
+
+    override val klass: KClass<LinScript> = LinScript::class
+
+    override fun OpenSpiralLanguageParser.syntax(): Rule =
+            Sequence(
+                    clearTmpStack(cmd),
+
+                    Sequence(
+                            "Focus camera on",
+                            pushDrillHead(cmd, this@LinCameraFocusDrill),
+                            InlineWhitespace(),
+                            FirstOf(
+                                    Parameter(cmd),
+                                    Sequence(
+                                            OneOrMore(Digit()),
+                                            pushTmpAction(cmd)
+                                    )
+                            ),
+                            pushTmpAction(cmd)
+                    ),
+
+                    pushStackWithHead(cmd)
+            )
+
+    override fun operate(parser: OpenSpiralLanguageParser, rawParams: Array<Any>): LinScript {
+        val uiStateStr = rawParams[0].toString()
+
+        val uiState: Int
+
+        uiState = uiStateStr.toIntOrNull() ?: 0
+
+        return when(parser.hopesPeakGame) {
+            DR1 -> ChangeUIEntry(26, uiState)
+            else -> TODO("Camera focus is not documented for ${parser.hopesPeakGame}")
+        }
+    }
+}


### PR DESCRIPTION
Adds a camera focus drill that sets the current focus of the camera in rooms.

DR1-Only right now, not sure what if the UI element is the same in DR2.

First attempt to add a new drill, hopefully it works fine. The OSL class verified it as compiling correctly (I think?) so should be good.